### PR TITLE
Dockerfile: add zlib1g-dev and lib32stdc++-5-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM crops/poky:ubuntu-16.04
 
 USER root
-RUN apt-get update && apt-get install -y vim rpm git
+RUN apt-get update && apt-get install -y vim rpm git zlib1g-dev lib32stdc++-5-dev
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* zlib1g-dev is needed to build qtbase-native
* lib32stdc++-5-dev is needed to build qtwebengine

Change-Id: I81ff786c799fe36f3c1176728a3a2e867a109946